### PR TITLE
Override de la methode toMail afin de definir une route personalisee

### DIFF
--- a/src/Notifications/ResetPassword.php
+++ b/src/Notifications/ResetPassword.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace LaravelAdminPackage\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+
+class ResetPassword extends \Illuminate\Auth\Notifications\ResetPassword
+{
+    /**
+     * Build the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return (new MailMessage)
+            ->line('You are receiving this email because we received a password reset request for your account.')
+            ->action('Reset Password', url(config('app.url').route(config('admin.user_passwor_reset_route'), $this->token, false)))
+            ->line('If you did not request a password reset, no further action is required.');
+    }
+}

--- a/src/Notifications/ResetPassword.php
+++ b/src/Notifications/ResetPassword.php
@@ -16,7 +16,7 @@ class ResetPassword extends \Illuminate\Auth\Notifications\ResetPassword
     {
         return (new MailMessage)
             ->line('You are receiving this email because we received a password reset request for your account.')
-            ->action('Reset Password', url(config('app.url').route(config('admin.user_passwor_reset_route'), $this->token, false)))
+            ->action('Reset Password', url(config('app.url').route(config('admin.user_password_reset_route'), $this->token, false)))
             ->line('If you did not request a password reset, no further action is required.');
     }
 }

--- a/src/Routing/Router.php
+++ b/src/Routing/Router.php
@@ -23,7 +23,7 @@ class Router extends \Illuminate\Routing\Router
         // Password Reset Routes...
         $this->get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm')->name('passwordReset');
         $this->post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail')->name('passwordSendEmail');
-        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm');
+        $this->get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm')->name('passwordResetForm');
         $this->post('password/reset', 'Auth\ResetPasswordController@reset');
     }
 

--- a/src/config/admin.php
+++ b/src/config/admin.php
@@ -15,7 +15,7 @@ return [
 
     // Fully qualified namespace of the User model
     'user_model_fqn'       => '\App\Models\User',
-    'user_passwor_reset_route' => 'auth.passwordReset',
+    'user_password_reset_route' => 'auth.passwordResetForm',
 
     // Should we use the default package auth routes and controllers?
     'use_default_auth'     => true,

--- a/src/config/admin.php
+++ b/src/config/admin.php
@@ -15,6 +15,7 @@ return [
 
     // Fully qualified namespace of the User model
     'user_model_fqn'       => '\App\Models\User',
+    'user_passwor_reset_route' => 'auth.passwordReset',
 
     // Should we use the default package auth routes and controllers?
     'use_default_auth'     => true,

--- a/src/resources/views/auth/emails/password.blade.php
+++ b/src/resources/views/auth/emails/password.blade.php
@@ -1,4 +1,0 @@
-Vous avez demandé à récupérer votre mot de passe.
-Vous pouvez le réinitialiser en cliquant ici :
-@php($route = route('admin.passwordReset', $token))
-<a href="{{ $route }}">{{ $route }}</a>


### PR DESCRIPTION
Par défaut Laravel (5.4) cherche la route 'password.reset' pour envoyer un mail, or la route du package se nomme "auth.passwordReset'.

Override de \Illuminate\Auth\Notifications\ResetPassword afin de définir une route personnalisée pour envoyer un mail de notification.

Changement à prévoir dans le model user (peut-être remplacé celui par défaut de Laravel par un custom qui inclut directement les changements ci-dessous ? @mathieutu )

```php
    use LaravelAdminPackage\Notifications\ResetPassword as ResetPasswordNotification;

    public function sendPasswordResetNotification($token)
    {
        $this->notify(new ResetPasswordNotification($token));
    }
```